### PR TITLE
Avoid segfaulting when --container is not specified.

### DIFF
--- a/pkg/v3ctl/v3ctl.go
+++ b/pkg/v3ctl/v3ctl.go
@@ -97,24 +97,26 @@ func (rc *RootCommandeer) initialize() error {
 		return errors.Wrap(err, "Failed to create v3io context")
 	}
 
-	if rc.containerName != "" {
-		session, err := rc.dataPlaneContext.NewSessionSync(&v3io.NewSessionInput{
-			Username:  rc.username,
-			Password:  rc.password,
-			AccessKey: rc.accessKey,
-		})
+	if rc.containerName == "" {
+		return errors.New("Container must be specified (use --container)")
+	}
 
-		if err != nil {
-			return errors.Wrap(err, "Failed to create session")
-		}
+	session, err := rc.dataPlaneContext.NewSessionSync(&v3io.NewSessionInput{
+		Username:  rc.username,
+		Password:  rc.password,
+		AccessKey: rc.accessKey,
+	})
 
-		rc.container, err = session.NewContainer(&v3io.NewContainerInput{
-			ContainerName: rc.containerName,
-		})
+	if err != nil {
+		return errors.Wrap(err, "Failed to create session")
+	}
 
-		if err != nil {
-			return errors.Wrap(err, "Failed to open container")
-		}
+	rc.container, err = session.NewContainer(&v3io.NewContainerInput{
+		ContainerName: rc.containerName,
+	})
+
+	if err != nil {
+		return errors.Wrap(err, "Failed to open container")
 	}
 
 	return nil


### PR DESCRIPTION
Before:
```
v3ctl delete stream name
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x1447358]

goroutine 1 [running]:
github.com/v3io/v3ctl/pkg/v3ctl.newDeleteStreamCommandeer.func1(0xc0001cef00, 0xc0000ab5f0, 0x1, 0x1, 0x0, 0x0)
	/Volumes/work/v3ctl/pkg/v3ctl/delete.go:162 +0x108
github.com/spf13/cobra.(*Command).execute(0xc0001cef00, 0xc0000ab5a0, 0x1, 0x1, 0xc0001cef00, 0xc0000ab5a0)
	/Volumes/work/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:762 +0x465
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000db680, 0x0, 0x1447dc9, 0xc0000e9f88)
	/Volumes/work/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852 +0x2c0
github.com/spf13/cobra.(*Command).Execute(...)
	/Volumes/work/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
github.com/v3io/v3ctl/pkg/v3ctl.(*RootCommandeer).Execute(...)
	/Volumes/work/v3ctl/pkg/v3ctl/v3ctl.go:37
main.main()
	/Volumes/work/v3ctl/cmd/v3ctl/main.go:12 +0x35
```

After:
```
v3ctl delete stream name

Error - Container must be specified (use --container)
    /Volumes/work/v3ctl/pkg/v3ctl/v3ctl.go:101

Call stack:
Container must be specified (use --container)
    /Volumes/work/v3ctl/pkg/v3ctl/v3ctl.go:101
Failed to initialize root
    /Volumes/work/v3ctl/pkg/v3ctl/delete.go:156
```